### PR TITLE
Package watcher should not watch test resources

### DIFF
--- a/core/editor-init.js
+++ b/core/editor-init.js
@@ -376,7 +376,7 @@ Editor.watchPackages = function ( cb ) {
         }
     }
     _packageWatcher = Chokidar.watch(src, {
-        ignored: [/[\/\\]\./, /[\/\\]bin/],
+        ignored: [/[\/\\]\./, /[\/\\]bin/, /[\/\\]test[\/\\]fixtures/],
         ignoreInitial: true,
         persistent: true,
     });


### PR DESCRIPTION
to prevent dead circulation