### PR TITLE
Improve/menu

### DIFF
--- a/core/editor-menu.js
+++ b/core/editor-menu.js
@@ -191,10 +191,22 @@ EditorMenu.prototype.clear = function () {
  * ```
  */
 EditorMenu.prototype.add = function ( path, template ) {
+    // in object mode, we should set label from path if not exists
+    if ( !Array.isArray(template) ) {
+        if ( !template.label && template.type !== 'separator' ) {
+            var start = path.lastIndexOf( '/' );
+            if ( start !== -1 ) {
+                template.label = path.slice( start + 1 );
+                path = path.slice( 0, start );
+            }
+        }
+    }
+
     EditorMenu.parseTemplate(template);
 
-    if ( !Array.isArray(template) )
+    if ( !Array.isArray(template) ) {
         template = [template];
+    }
 
     var menuItem = _getMenuItem( this.nativeMenu, path, true );
 
@@ -314,6 +326,10 @@ EditorMenu.parseTemplate = function ( template, webContents ) {
     }
 
     var args;
+
+    if ( template.label === undefined && template.type !== 'separator' ) {
+        Editor.warn('Missing label in template');
+    }
 
     if ( template.message ) {
         if ( template.click ) {

--- a/core/main-menu.js
+++ b/core/main-menu.js
@@ -274,13 +274,6 @@ MainMenu.reset = function () {
  * @param {object[]|object} template
  */
 MainMenu.add = function ( path, template ) {
-    if ( !template.label ) {
-        var start = path.lastIndexOf( '/' );
-        if ( start !== -1 ) {
-            template.label = path.slice( start + 1 );
-            path = path.slice( 0, start );
-        }
-    }
     if ( _mainMenu.add( path, template ) ) {
         MainMenu.apply();
     }

--- a/core/main-menu.js
+++ b/core/main-menu.js
@@ -274,6 +274,13 @@ MainMenu.reset = function () {
  * @param {object[]|object} template
  */
 MainMenu.add = function ( path, template ) {
+    if ( !template.label ) {
+        var start = path.lastIndexOf( '/' );
+        if ( start !== -1 ) {
+            template.label = path.slice( start + 1 );
+            path = path.slice( 0, start );
+        }
+    }
     if ( _mainMenu.add( path, template ) ) {
         MainMenu.apply();
     }

--- a/test/menu.js
+++ b/test/menu.js
@@ -39,4 +39,42 @@ describe('Editor.Menu', function() {
 
         done();
     });
+
 });
+
+describe('Editor.MainMenu', function() {
+
+    var MainMenu = Editor.MainMenu;
+    var addmenu;
+    before(function() {
+        addmenu = sinon.stub(Editor.Menu.prototype, 'add');
+    });
+    after(function() {
+        addmenu.restore();
+    });
+
+    describe('.add', function() {
+        it('should add path and label', function() {
+            MainMenu.add('foo/bar', {
+                'label': 'zoo',
+                'message': 'hint'
+            });
+            expect( addmenu.firstCall.args[0] ).to.equal('foo/bar');
+            expect( addmenu.firstCall.args[1] ).to.deep.equal({
+                'label': 'zoo',
+                'message': 'hint'
+            });
+        });
+        it('should add path without label', function() {
+            MainMenu.add('foo/bar/zom', {
+                'message': 'hint'
+            });
+            expect( addmenu.secondCall.args[0] ).to.equal('foo/bar');
+            expect( addmenu.secondCall.args[1] ).to.deep.equal({
+                'label': 'zom',
+                'message': 'hint'
+            });
+        });
+    });
+
+})

--- a/test/menu.js
+++ b/test/menu.js
@@ -40,41 +40,14 @@ describe('Editor.Menu', function() {
         done();
     });
 
+    it('should add menu item through template without label', function (done) {
+        var testMenu = new Editor.Menu();
+        testMenu.add('tar/zom', {'message': 'hint'});
+
+        expect( testMenu.nativeMenu.items[0].label ).to.equal('tar');
+        expect( testMenu.nativeMenu.items[0].submenu.items[0].label ).to.equal('zom');
+
+        done();
+    });
+
 });
-
-describe('Editor.MainMenu', function() {
-
-    var MainMenu = Editor.MainMenu;
-    var addmenu;
-    before(function() {
-        addmenu = sinon.stub(Editor.Menu.prototype, 'add');
-    });
-    after(function() {
-        addmenu.restore();
-    });
-
-    describe('.add', function() {
-        it('should add path and label', function() {
-            MainMenu.add('foo/bar', {
-                'label': 'zoo',
-                'message': 'hint'
-            });
-            expect( addmenu.firstCall.args[0] ).to.equal('foo/bar');
-            expect( addmenu.firstCall.args[1] ).to.deep.equal({
-                'label': 'zoo',
-                'message': 'hint'
-            });
-        });
-        it('should add path without label', function() {
-            MainMenu.add('foo/bar/zom', {
-                'message': 'hint'
-            });
-            expect( addmenu.secondCall.args[0] ).to.equal('foo/bar');
-            expect( addmenu.secondCall.args[1] ).to.deep.equal({
-                'label': 'zom',
-                'message': 'hint'
-            });
-        });
-    });
-
-})


### PR DESCRIPTION
Set the label from `arguments[0]` if the `template.label` doesn't get set by caller, this could make compatible with the following call:

```js
Editor.MainMenu.add('File/Save', { 'message': 'channel' })
```

@jwu I'm quite not sure if this is a real correct patch because it breaks the SRP. In the other hand, it actually makes sense to help developer to fix some of mistakes in this API.