### PR TITLE
Fix license to the SPDX License format

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/fireball-x/editor-framework.git"
   },
   "author": "Firebox Technology",
-  "license": "MIT License",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/fireball-x/editor-framework/issues"
   },


### PR DESCRIPTION
Removes the following warning:
<img width="1020" alt="screen shot 2015-10-30 at 2 14 28 pm" src="https://cloud.githubusercontent.com/assets/432489/10855744/481a5724-7f11-11e5-86ce-439ba5af8ccd.png">
SPDX info for MIT license can be found here: http://spdx.org/licenses/MIT.html